### PR TITLE
Calculate line count for run without changes instead of taking a CLI argument

### DIFF
--- a/dehydrated/README.md
+++ b/dehydrated/README.md
@@ -27,5 +27,4 @@ I use the following cron entries (for root):
 
 ## Next steps
 
-* The line count is implemented to get an e-mail when deyhdrated issues new certificates. Obviously this should be done (at least) via a grep for signal strings or via a special return code in dehydrated.
 * Configuration should be kept outside the scripts.

--- a/dehydrated/README.md
+++ b/dehydrated/README.md
@@ -4,13 +4,13 @@ Wrap dehydrated calls so that cron e-mails are only sent when the call fails or 
 
 ## Usage
 
-Currently dehydrated is assumed at `/usr/local/bin/dehydrated` with it's configuration in `/usr/local/etc/dehydrated`. If you have a different setup, you need to adapt the scripts accordingly.
+Currently dehydrated is assumed at `/usr/local/bin/dehydrated` with it's domain configuration in `/usr/local/etc/dehydrated/domains.txt`. If you have a different setup, please adapt the scripts accordingly.
 
 ### dehy-wrap.sh
 
 Configuration (so far) is in the script itself if necessary.
 
-When an integer command-line argument is provided, the script will output its result if it has more lines than this number states.
+The script calculates the number of "idle" (i.e. nothing needs to be done) output lines based on the number of entries in your `domains.txt` configuration.
 
 ### dehy-check.sh
 
@@ -21,7 +21,7 @@ This is an indication for a malfunctioning dehydrated setup.
 
 I use the following cron entries (for root):
 ```
-0 3 * * * /usr/local/bin/dehy-wrap.sh 6
+0 3 * * * /usr/local/bin/dehy-wrap.sh
 0 4 * * * /usr/local/bin/dehy-check.sh
 ```
 

--- a/dehydrated/dehy-wrap.sh
+++ b/dehydrated/dehy-wrap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+DOMAINS="/usr/local/etc/dehydrated/domains.txt"
 DEHYDRATED="/usr/local/bin/dehydrated"
 CALL="$DEHYDRATED -c"
 
@@ -12,10 +13,9 @@ if [ "0${RETURN}" -ne "0" ]; then
     echo "$RESULT"
 fi
 
-if [ ! -z "$1" ]; then
-    LTRG=$1
-    LEN=$(echo "$RESULT" | wc -l)
-    if [ $LEN -gt $LTRG ]; then
-        echo "$RESULT"
-    fi
+LTRG=$(( $( cat $DOMAINS | wc -l )  * 5 + 1))
+
+LEN=$(echo "$RESULT" | wc -l)
+if [ $LEN -gt $LTRG ]; then
+    echo "$RESULT"
 fi


### PR DESCRIPTION
The count is calculated as follows:
* 1 line initial output
* 5 lines per domain in `domains.txt` if nothing needs to be done