### PR TITLE
Call Docker exec without terminal

### DIFF
--- a/tw_backup.sh
+++ b/tw_backup.sh
@@ -10,6 +10,9 @@
 # For the process see
 # https://twenty.com/developers/section/self-hosting/upgrade-guide
 #
+# Note: This script is intended to be run from a cron job and therefore does not
+# have access to a terminal. All output is sent to stdout/stderr.
+#
 # Author: Stefan Haun <tux@netz39.de>
 #
 # SPDX-License-Identifier: MIT

--- a/tw_backup.sh
+++ b/tw_backup.sh
@@ -74,7 +74,7 @@ pushd "$TMPDIR" || exit
 
 ## Dump Database
 echo "Dumping database …"
-$DOCKER exec -it $DEFAULT_TW_DB_INSTANCE pg_dumpall -U "$TW_POSTGRES_USER" > "$TMPDIR/tw_database.sql"
+$DOCKER exec $DEFAULT_TW_DB_INSTANCE pg_dumpall -U "$TW_POSTGRES_USER" > "$TMPDIR/tw_database.sql"
 $BZIP2 "$TMPDIR/tw_database.sql"
 
 ## Copy to backup location


### PR DESCRIPTION
The CRON call does not offer a terminal, so docker must be used without terminal invocation.