### PR TITLE
AKG Helper: Try re-grabbing the device on boot-up and show microphone value on OSD

### DIFF
--- a/akg-ara/akg-ara-mic-wpctl.py
+++ b/akg-ara/akg-ara-mic-wpctl.py
@@ -96,6 +96,27 @@ def find_pw_source_id() -> str:
 
     return None
 
+def get_volume_percent(source_id: str) -> int | None:
+    output = run(["wpctl", "get-volume", source_id])
+
+    # Example:
+    # Volume: 1.25 [MUTED]
+    m = re.search(r"Volume:\s+([0-9.]+)", output)
+    if not m:
+        return None
+
+    return round(float(m.group(1)) * 100)
+
+
+def show_microphone_osd(percent: int) -> None:
+    run([
+        "qdbus6",
+        "org.kde.plasmashell",
+        "/org/kde/osdService",
+        "org.kde.osdService.microphoneVolumeChanged",
+        str(percent),
+    ])
+
 def handle_key(code: int, value: int, source_id: str) -> None:
     # value: 1=press, 0=release, 2=autorepeat
     if value != 1:
@@ -107,6 +128,10 @@ def handle_key(code: int, value: int, source_id: str) -> None:
         run(["wpctl", "set-volume", source_id, f"{STEP}-"])
     elif code in (ecodes.KEY_MICMUTE, ecodes.KEY_MUTE):
         run(["wpctl", "set-mute", source_id, "toggle"])
+
+    percent = get_volume_percent(source_id)
+    if percent is not None:
+        show_microphone_osd(percent)
 
 def main() -> int:
     source_id = None

--- a/akg-ara/akg-ara-mic-wpctl.py
+++ b/akg-ara/akg-ara-mic-wpctl.py
@@ -19,7 +19,7 @@ PW_SOURCE_NAME_MATCH = "AKG Ara USB Microphone Mono"
 
 STEP = "5%"  # volume step
 
-def run(cmd: list[str]) -> str:
+def run(cmd: list[str]) -> str | None:
     """Run a shell command and return stdout as text."""
     result = subprocess.run(cmd,
                             check=False,
@@ -34,12 +34,12 @@ def find_input_device() -> InputDevice:
         dev = InputDevice(path)
         if INPUT_NAME_MATCH in dev.name:
             return dev
-    print(f"Warn: could not find input device matching '{INPUT_NAME_MATCH}'", file=sys.stdio)
+    print(f"Warn: could not find input device matching '{INPUT_NAME_MATCH}'", file=sys.stdout)
 
     return None
 
 
-def find_pw_source_id() -> str:
+def find_pw_source_id() -> str | None:
     """
     Parse `wpctl status` and return the ID of the audio source whose name
     contains PW_SOURCE_NAME_MATCH.
@@ -91,7 +91,7 @@ def find_pw_source_id() -> str:
 
     print(
         f"Warn: could not find PipeWire source matching '{PW_SOURCE_NAME_MATCH}'",
-        file=sys.stdio,
+        file=sys.stdout,
     )
 
     return None

--- a/akg-ara/akg-ara-mic-wpctl.py
+++ b/akg-ara/akg-ara-mic-wpctl.py
@@ -9,6 +9,7 @@ from evdev import InputDevice, list_devices, ecodes
 import subprocess
 import sys
 import re
+import time
 
 # Substring of the input device name as shown by evtest/lsinput
 INPUT_NAME_MATCH = "C-Media Electronics Inc. AKG Ara USB Microphone"
@@ -33,8 +34,9 @@ def find_input_device() -> InputDevice:
         dev = InputDevice(path)
         if INPUT_NAME_MATCH in dev.name:
             return dev
-    print(f"Error: could not find input device matching '{INPUT_NAME_MATCH}'", file=sys.stderr)
-    sys.exit(1)
+    print(f"Warn: could not find input device matching '{INPUT_NAME_MATCH}'", file=sys.stdio)
+
+    return None
 
 
 def find_pw_source_id() -> str:
@@ -88,10 +90,11 @@ def find_pw_source_id() -> str:
             return source_id
 
     print(
-        f"Error: could not find PipeWire source matching '{PW_SOURCE_NAME_MATCH}'",
-        file=sys.stderr,
+        f"Warn: could not find PipeWire source matching '{PW_SOURCE_NAME_MATCH}'",
+        file=sys.stdio,
     )
-    sys.exit(1)
+
+    return None
 
 def handle_key(code: int, value: int, source_id: str) -> None:
     # value: 1=press, 0=release, 2=autorepeat
@@ -106,12 +109,47 @@ def handle_key(code: int, value: int, source_id: str) -> None:
         run(["wpctl", "set-mute", source_id, "toggle"])
 
 def main() -> int:
-    # Resolve the PipeWire source ID at startup
-    source_id = find_pw_source_id()
-    print(f"Using PipeWire source ID: {source_id}")
+    source_id = None
+    dev = None
 
-    # Find the AKG Ara input device by name
-    dev = find_input_device()
+    RETRY_INTERVAL = 0.5
+    RETRY_COUNT = 20
+
+    for attempt in range(1, RETRY_COUNT + 1):
+        if source_id is None:
+            # Resolve the PipeWire source ID at startup
+            source_id = find_pw_source_id()
+
+        if dev is None:
+            # Find the AKG Ara input device by name
+            dev = find_input_device()
+
+        if source_id is not None and dev is not None:
+                    break
+
+        if attempt < RETRY_COUNT:
+            time.sleep(RETRY_INTERVAL)
+    # for
+
+    if source_id is None:
+        print(
+            f"Error: could not find PipeWire source matching "
+            f"'{PW_SOURCE_NAME_MATCH}' after "
+            f"{RETRY_COUNT * RETRY_INTERVAL:.1f}s",
+            file=sys.stderr,
+        )
+        return 1
+
+    if dev is None:
+        print(
+            f"Error: could not find input device matching "
+            f"'{INPUT_NAME_MATCH}' after "
+            f"{RETRY_COUNT * RETRY_INTERVAL:.1f}s",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Using PipeWire source ID: {source_id}")
     print(f"Listening on {dev.path} ({dev.name})")
 
     # Grab the device so the events do not also reach the desktop/system


### PR DESCRIPTION
This pull request improves the robustness and user experience of the `akg-ara-mic-wpctl.py` script by making device detection more fault-tolerant, adding retry logic, and enhancing feedback to the user. The script now attempts to find required devices multiple times before failing, and displays on-screen feedback for microphone volume changes.

**Robustness and error handling:**

* Changed device and source lookup functions (`find_input_device`, `find_pw_source_id`) to return `None` and print warnings instead of exiting immediately, allowing for retry logic and more graceful error handling. [[1]](diffhunk://#diff-bb740bdb08da07187729223de203bdd5907adf90f445eb09487d6eaab16e9c70L36-R42) [[2]](diffhunk://#diff-bb740bdb08da07187729223de203bdd5907adf90f445eb09487d6eaab16e9c70L91-R118)
* Added retry logic at startup: the script now attempts to find both the PipeWire source and the input device up to 20 times with a 0.5s interval before giving up, providing clear error messages on failure.

**User feedback improvements:**

* Introduced `get_volume_percent` and `show_microphone_osd` functions to display an on-screen display (OSD) of the microphone volume after each relevant key event, improving user awareness of volume changes. [[1]](diffhunk://#diff-bb740bdb08da07187729223de203bdd5907adf90f445eb09487d6eaab16e9c70L91-R118) [[2]](diffhunk://#diff-bb740bdb08da07187729223de203bdd5907adf90f445eb09487d6eaab16e9c70R132-R177)

**Code and type improvements:**

* Updated function signatures to use more accurate return types (e.g., `str | None`), reflecting the new error handling approach. [[1]](diffhunk://#diff-bb740bdb08da07187729223de203bdd5907adf90f445eb09487d6eaab16e9c70L21-R22) [[2]](diffhunk://#diff-bb740bdb08da07187729223de203bdd5907adf90f445eb09487d6eaab16e9c70L36-R42) [[3]](diffhunk://#diff-bb740bdb08da07187729223de203bdd5907adf90f445eb09487d6eaab16e9c70L91-R118)
* Added import of the `time` module to support the new retry logic.